### PR TITLE
Make default more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Inputs:
 |---------------------------|----------------|----------------------|----------------------------------------------------------------------------------------------------|
 | `url`                     | HTTP(S) url    | yes                  | URL of the file to download.                                                                       |
 | `destination`             | file path      | yes                  | Path to load the cached file from, or save the downloaded file to.                                 |
-| `cache-key`               | string         | no (default ``)      | An explicit key for a cache entry.                                                                 |
+| `cache-key`               | string         | no (defaults to url) | An explicit key for a cache entry.                                                                 |
 | `enable-cross-os-archive` | boolean        | no (default `false`) | See `enableCrossOsArchive` input in [actions/cache](https://github.com/marketplace/actions/cache). |
 
 - If `cache-key` is empty, then the `url` input will be used as the cache key instead.


### PR DESCRIPTION
The markdown rendering of the empty cache-key was strange. I wanted to add

    `''`

but I thought an explicit description would be nice.

I left the "If" comment intact since this handles a slightly different case.